### PR TITLE
Grant Claude minimal write permissions for issues management

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -21,7 +21,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
-      issues: read
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Summary
- Changed issues permission from `read` to `write`
- Enables Claude to create issues and manage labels
- Maintains minimal permission scope (read-only for contents/PRs)

## Changes
- `.github/workflows/claude.yml`: `issues: read` → `issues: write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)