### PR TITLE
Increase difficulty for stronger opponents

### DIFF
--- a/PoCs/arcade-shooter/src/enemies.ts
+++ b/PoCs/arcade-shooter/src/enemies.ts
@@ -24,6 +24,7 @@ export interface EnemyProperties {
   shootInterval: number;
   canShoot: boolean;
   hp: number;
+  points: number;
 }
 
 // Get properties for enemy type
@@ -38,6 +39,7 @@ export function getEnemyProperties(type: EnemyType): EnemyProperties {
         shootInterval: 1000,
         canShoot: true,
         hp: 1,
+        points: 10,
       };
 
     case EnemyType.YELLOW:
@@ -49,6 +51,7 @@ export function getEnemyProperties(type: EnemyType): EnemyProperties {
         shootInterval: 1500,
         canShoot: true,
         hp: 1,
+        points: 20,
       };
 
     case EnemyType.PURPLE:
@@ -60,6 +63,7 @@ export function getEnemyProperties(type: EnemyType): EnemyProperties {
         shootInterval: 0,
         canShoot: false,
         hp: 1,
+        points: 25,
       };
 
     case EnemyType.TANK:
@@ -71,6 +75,7 @@ export function getEnemyProperties(type: EnemyType): EnemyProperties {
         shootInterval: 2000,
         canShoot: true,
         hp: 5,
+        points: 50,
       };
   }
 }

--- a/PoCs/arcade-shooter/src/main.ts
+++ b/PoCs/arcade-shooter/src/main.ts
@@ -218,8 +218,9 @@ function update() {
 
         // Remove enemy if HP depleted
         if (enemy.hp <= 0) {
+          const points = getEnemyProperties(enemy.type).points;
           game.enemies.splice(i, 1);
-          game.score += 10;
+          game.score += points;
           updateScore();
         }
         return false; // bullet is consumed


### PR DESCRIPTION
Implement point scaling system where stronger enemies provide greater rewards:
- STANDARD: 10 points (baseline, 1 HP)
- YELLOW: 20 points (bigger, spread shots)
- PURPLE: 25 points (fast, tracks player)
- TANK: 50 points (5 HP, toughest enemy)

This makes the reward system fair - TANK now gives 5x more points than STANDARD, reflecting its 5x health requirement.