### PR TITLE
Increase screen size and slow down game

### DIFF
--- a/PoCs/arcade-shooter/src/enemies.ts
+++ b/PoCs/arcade-shooter/src/enemies.ts
@@ -168,21 +168,23 @@ export function createEnemy(
  * @param playerY - Current player Y position (unused currently)
  * @param playerWidth - Player width for centering calculations
  * @param canvasWidth - Canvas width for boundary checks
+ * @param gameSpeed - Global game speed multiplier (< 1 to slow down, > 1 to speed up)
  */
 export function updateEnemyMovement(
   enemy: Enemy,
   playerX: number,
   playerY: number,
   playerWidth: number,
-  canvasWidth: number
+  canvasWidth: number,
+  gameSpeed: number
 ): void {
   const props = getEnemyProperties(enemy.type);
 
   switch (enemy.type) {
     case EnemyType.STANDARD:
       // Move down and bounce horizontally
-      enemy.y += enemy.vy;
-      enemy.x += enemy.vx;
+      enemy.y += enemy.vy * gameSpeed;
+      enemy.x += enemy.vx * gameSpeed;
 
       if (enemy.x <= 0 || enemy.x >= canvasWidth - enemy.width) {
         enemy.vx = -enemy.vx;
@@ -192,8 +194,8 @@ export function updateEnemyMovement(
 
     case EnemyType.YELLOW:
       // Can move backward (up) sometimes
-      enemy.y += enemy.vy;
-      enemy.x += enemy.vx;
+      enemy.y += enemy.vy * gameSpeed;
+      enemy.x += enemy.vx * gameSpeed;
 
       // Randomly reverse vertical direction, but not if too far up
       if (Math.random() < 0.01 && enemy.y > 50) {
@@ -219,13 +221,13 @@ export function updateEnemyMovement(
 
       // Move toward player horizontally
       if (centerX < targetX - 5) {
-        enemy.x += props.horizontalSpeed;
+        enemy.x += props.horizontalSpeed * gameSpeed;
       } else if (centerX > targetX + 5) {
-        enemy.x -= props.horizontalSpeed;
+        enemy.x -= props.horizontalSpeed * gameSpeed;
       }
 
       // Move down
-      enemy.y += props.speed;
+      enemy.y += props.speed * gameSpeed;
 
       // Keep in bounds
       enemy.x = Math.max(0, Math.min(enemy.x, canvasWidth - enemy.width));
@@ -233,8 +235,8 @@ export function updateEnemyMovement(
 
     case EnemyType.TANK:
       // Slow, steady movement
-      enemy.y += enemy.vy;
-      enemy.x += enemy.vx;
+      enemy.y += enemy.vy * gameSpeed;
+      enemy.x += enemy.vx * gameSpeed;
 
       if (enemy.x <= 0 || enemy.x >= canvasWidth - enemy.width) {
         enemy.vx = -enemy.vx;

--- a/PoCs/arcade-shooter/src/main.ts
+++ b/PoCs/arcade-shooter/src/main.ts
@@ -16,9 +16,11 @@ import { Bullet, draw as renderGame, drawGameOver as renderGameOver } from './re
  */
 const CONFIG = {
   /** Canvas width in pixels */
-  CANVAS_WIDTH: 400,
+  CANVAS_WIDTH: 600,
   /** Canvas height in pixels */
-  CANVAS_HEIGHT: 600,
+  CANVAS_HEIGHT: 900,
+  /** Global game speed multiplier (< 1 to slow down, > 1 to speed up) */
+  GAME_SPEED: 0.7,
   /** Player movement speed in pixels per frame */
   PLAYER_SPEED: 5,
   /** Player triangle size (width and height) in pixels */
@@ -173,22 +175,24 @@ function update() {
   const now = Date.now();
 
   // Move player
+  const playerSpeed = CONFIG.PLAYER_SPEED * CONFIG.GAME_SPEED;
   if (game.keys.left && game.player.x > 0) {
-    game.player.x -= CONFIG.PLAYER_SPEED;
+    game.player.x -= playerSpeed;
   }
   if (game.keys.right && game.player.x < CONFIG.CANVAS_WIDTH - game.player.width) {
-    game.player.x += CONFIG.PLAYER_SPEED;
+    game.player.x += playerSpeed;
   }
   if (game.keys.up && game.player.y > 0) {
-    game.player.y -= CONFIG.PLAYER_SPEED;
+    game.player.y -= playerSpeed;
   }
   if (game.keys.down && game.player.y < CONFIG.CANVAS_HEIGHT - game.player.height) {
-    game.player.y += CONFIG.PLAYER_SPEED;
+    game.player.y += playerSpeed;
   }
 
   // Player shooting
+  const bulletSpeed = CONFIG.BULLET_SPEED * CONFIG.GAME_SPEED;
   if (game.keys.space && now - game.lastPlayerShot > CONFIG.PLAYER_SHOOT_INTERVAL) {
-    game.bullets.push(createBullet(game.player, -CONFIG.BULLET_SPEED));
+    game.bullets.push(createBullet(game.player, -bulletSpeed));
     game.lastPlayerShot = now;
   }
 
@@ -225,7 +229,7 @@ function update() {
   // Move enemies and make them shoot
   game.enemies = game.enemies.filter((enemy) => {
     // Update movement based on enemy type
-    updateEnemyMovement(enemy, game.player.x, game.player.y, game.player.width, CONFIG.CANVAS_WIDTH);
+    updateEnemyMovement(enemy, game.player.x, game.player.y, game.player.width, CONFIG.CANVAS_WIDTH, CONFIG.GAME_SPEED);
 
     // Enemy shooting
     const props = getEnemyProperties(enemy.type);
@@ -234,7 +238,7 @@ function update() {
         // Yellow enemies shoot three bullets: left diagonal, center straight, right diagonal
         const centerX = enemy.x + enemy.width / 2;
         const bottomY = enemy.y + enemy.height;
-        const bulletSpeed = CONFIG.BULLET_SPEED * CONFIG.ENEMY_BULLET_SPEED_MULT;
+        const bulletSpeed = CONFIG.BULLET_SPEED * CONFIG.ENEMY_BULLET_SPEED_MULT * CONFIG.GAME_SPEED;
 
         // Left diagonal bullet
         const leftBullet = createBullet(enemy, bulletSpeed);
@@ -256,7 +260,7 @@ function update() {
         game.enemyBullets.push(rightBullet);
       } else {
         // Standard straight bullet
-        const bullet = createBullet(enemy, CONFIG.BULLET_SPEED * CONFIG.ENEMY_BULLET_SPEED_MULT);
+        const bullet = createBullet(enemy, CONFIG.BULLET_SPEED * CONFIG.ENEMY_BULLET_SPEED_MULT * CONFIG.GAME_SPEED);
         bullet.y = enemy.y + enemy.height;
         game.enemyBullets.push(bullet);
       }


### PR DESCRIPTION
- Canvas size: 400x600 → 600x900 (50% larger in both dimensions)
- Add GAME_SPEED multiplier: 0.7 (30% slower gameplay)
- Apply game speed to all movement systems:
  - Player movement
  - Bullet speeds (player and enemies)
  - Enemy movement (all types: STANDARD, YELLOW, PURPLE, TANK)