### PR TITLE
Fix enemy spawning in main branch

### DIFF
--- a/PoCs/arcade-shooter/src/main.ts
+++ b/PoCs/arcade-shooter/src/main.ts
@@ -231,7 +231,7 @@ function update() {
   // Move enemies and make them shoot
   game.enemies = game.enemies.filter((enemy) => {
     // Update movement based on enemy type
-    updateEnemyMovement(enemy, game.player.x, game.player.y, game.player.width, CONFIG.CANVAS_WIDTH, CONFIG.CANVAS_HEIGHT, now);
+    updateEnemyMovement(enemy, game.player.x, game.player.y, game.player.width, CONFIG.CANVAS_WIDTH, CONFIG.CANVAS_HEIGHT, now, CONFIG.GAME_SPEED);
 
     // Enemy shooting
     const props = getEnemyProperties(enemy.type);


### PR DESCRIPTION
Enemies were not appearing because gameSpeed parameter was missing from the updateEnemyMovement call, causing NaN positions and immediate removal.