### PR TITLE
Standardize game canvas size across projects

### DIFF
--- a/PoCs/arcade-shooter-phaser/src/main.ts
+++ b/PoCs/arcade-shooter-phaser/src/main.ts
@@ -32,8 +32,8 @@ import { MainGameScene } from './MainGameScene';
  */
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO, // WebGL with Canvas fallback
-  width: 600,
-  height: 900,
+  width: 550,
+  height: 850,
   parent: 'gameContainer', // HTML container ID
   backgroundColor: '#16213e',
   physics: {

--- a/PoCs/arcade-shooter/index.html
+++ b/PoCs/arcade-shooter/index.html
@@ -196,7 +196,7 @@
 <body>
   <div id="gameContainer">
     <div id="score">Score: 0</div>
-    <canvas id="gameCanvas" class="disabled" width="400" height="600"></canvas>
+    <canvas id="gameCanvas" class="disabled" width="550" height="850"></canvas>
     <div id="controls" style="color: #fff; margin-top: 10px; opacity: 0.5;">
       Arrow keys: Move | Space: Shoot | <span style="color: #e94560;">Configure game below to start</span>
     </div>

--- a/PoCs/arcade-shooter/src/main.ts
+++ b/PoCs/arcade-shooter/src/main.ts
@@ -17,9 +17,9 @@ import { showEnemyIntroduction, isFirstEncounter, markAsEncountered } from './en
  */
 const CONFIG = {
   /** Canvas width in pixels */
-  CANVAS_WIDTH: 600,
+  CANVAS_WIDTH: 550,
   /** Canvas height in pixels */
-  CANVAS_HEIGHT: 900,
+  CANVAS_HEIGHT: 850,
   /** Global game speed multiplier (< 1 to slow down, > 1 to speed up) */
   GAME_SPEED: 0.5,
   /** Player movement speed in pixels per frame */


### PR DESCRIPTION
- Update Phaser project canvas dimensions from 600x900 to 550x850
- Update vanilla arcade shooter canvas from 400x600 to 550x850
- Update CONFIG constants in vanilla project to match
- Ensures consistent viewport across both implementations