### PR TITLE
Fix broken styles and undefined error in Phaser

### DIFF
--- a/PoCs/arcade-shooter-phaser/src/enemies.ts
+++ b/PoCs/arcade-shooter-phaser/src/enemies.ts
@@ -415,5 +415,11 @@ export function getEnemyMetadata(type: EnemyType): EnemyMetadata {
         name: 'Opancerzony Czołg',
         description: 'Masywny i powolny, ale niezwykle wytrzymały. Posiada 5 punktów życia - potrzeba wielu trafień, by go zniszczyć.',
       };
+
+    case EnemyType.TELEPORT:
+      return {
+        name: 'Teleporter',
+        description: 'Tajemniczy przeciwnik potrafiący teleportować się w niższe pozycje co sekundę. Strzela naprowadzanymi pociskami!',
+      };
   }
 }


### PR DESCRIPTION
Added missing EnemyType.TELEPORT case in getEnemyMetadata() function. Previously calling this function with TELEPORT type returned undefined, causing "Cannot read properties of undefined (reading 'name')" error when displaying enemy introduction modal.